### PR TITLE
fixed for premailer inline

### DIFF
--- a/templates/skyline/confirm.html
+++ b/templates/skyline/confirm.html
@@ -11,19 +11,13 @@
 
   img {
     max-width: 600px;
-    outline: none;
-    text-decoration: none;
     -ms-interpolation-mode: bicubic;
   }
 
-  a {
-    text-decoration: none;
-    border: 0;
-    outline: none;
-  }
-
   a img {
-    border: none;
+      border: 0;
+      outline: none;
+      text-decoration: none;
   }
 
   /* General styling */
@@ -43,7 +37,7 @@
   }
 
    table {
-    border-collapse: collapse !important;
+    border-collapse: collapse;
   }
 
 
@@ -65,11 +59,11 @@
   }
 
   .hide {
-    display: none !important;
+    display: none;
   }
 
   .force-full-width {
-    width: 100% !important;
+    width: 100%;
   }
 
 
@@ -80,7 +74,7 @@
       @media screen {
          /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
         td, h1, h2, h3 {
-          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
+          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif';
         }
       }
   </style>
@@ -90,51 +84,51 @@
     @media only screen and (max-width: 480px) {
 
       table[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       table[class="w300"] {
-        width: 300px !important;
+        width: 300px;
       }
 
       table[class="w290"] {
-        width: 290px !important;
+        width: 290px;
       }
 
       td[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       td[class="mobile-center"] {
-        text-align: center !important;
+        text-align: center;
       }
 
       td[class*="mobile-padding"] {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-        padding-bottom: 20px !important;
+        padding-left: 20px;
+        padding-right: 20px;
+        padding-bottom: 20px;
       }
 
       td[class*="mobile-block"] {
-        display: block !important;
-        width: 100% !important;
-        text-align: left !important;
-        padding-bottom: 20px !important;
+        display: block;
+        width: 100%;
+        text-align: left;
+        padding-bottom: 20px;
       }
 
       td[class*="mobile-border"] {
-        border: 0 !important;
+        border: 0;
       }
 
       td[class*="reveal"] {
-        display: block !important;
+        display: block;
 
       }
 
     }
   </style>
 </head>
-<body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
+<body class="body" style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
 <table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
   <tr>
     <td align="center" valign="top" bgcolor="#ffffff"  width="100%">
@@ -154,7 +148,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG); background-color: #8b8284; background-position: center !important;">
+        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG); background-color: #8b8284; background-position: center;">
 
 
 

--- a/templates/skyline/invite.html
+++ b/templates/skyline/invite.html
@@ -11,19 +11,13 @@
 
   img {
     max-width: 600px;
-    outline: none;
-    text-decoration: none;
     -ms-interpolation-mode: bicubic;
   }
 
-  a {
-    text-decoration: none;
-    border: 0;
-    outline: none;
-  }
-
   a img {
-    border: none;
+      border: 0;
+      outline: none;
+      text-decoration: none;
   }
 
   /* General styling */
@@ -43,7 +37,7 @@
   }
 
   table {
-    background:
+    background: #ffffff;
   }
 
   h1, h2, h3 {
@@ -64,7 +58,7 @@
       @media screen {
          /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
         td, h1, h2, h3 {
-          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
+          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif';
         }
       }
   </style>
@@ -74,53 +68,53 @@
     @media only screen and (max-width: 480px) {
 
       table[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       table[class="w300"] {
-        width: 300px !important;
+        width: 300px;
       }
 
       table[class="w290"] {
-        width: 290px !important;
+        width: 290px;
       }
 
       td[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       table[class*="w260"] {
-        width: 260px !important;
+        width: 260px;
       }
 
       td[class*="mobile-center"] {
-        text-align: center !important;
+        text-align: center;
       }
 
       td[class*="mobile-padding"] {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-        padding-bottom: 20px !important;
+        padding-left: 20px;
+        padding-right: 20px;
+        padding-bottom: 20px;
       }
 
       td[class*="mobile-block"] {
-        display: block !important;
-        width: 280px !important;
-        text-align: left !important;
-        padding-bottom: 20px !important;
+        display: block;
+        width: 280px;
+        text-align: left;
+        padding-bottom: 20px;
       }
 
       td[class*="mobile-img"] {
-        display: block !important;
-        width: 100% !important;
-        text-align: center !important;
-        padding-bottom: 20px !important;
-        width:320px !important;
+        display: block;
+        width: 100%;
+        text-align: center;
+        padding-bottom: 20px;
+        width:320px;
       }
     }
   </style>
 </head>
-<body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
+<body class="body" style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
 <table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
   <tr>
     <td align="center" valign="top" bgcolor="#ffffff"  width="100%">
@@ -140,7 +134,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" bgcolor="#0d0102" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU); background-color: #0d0102; background-position: center !important;">
+        <td background="https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" bgcolor="#0d0102" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU); background-color: #0d0102; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="hhttps://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" color="#0d0102" />
@@ -191,7 +185,7 @@
                   <table style="margin: 0 auto;" cellspacing="0" cellpadding="8" width="180">
                     <tr>
                       <td style="border: 1px solid #a1a1a1; text-align:center;">
-                        Code: <span style="font-family: Courier !important;">4562789498</span>
+                        Code: <span style="font-family: Courier;">4562789498</span>
                       </td>
                     </tr>
                   </table>

--- a/templates/skyline/invoice.html
+++ b/templates/skyline/invoice.html
@@ -11,19 +11,13 @@
 
   img {
     max-width: 600px;
-    outline: none;
-    text-decoration: none;
     -ms-interpolation-mode: bicubic;
   }
 
-  a {
-    text-decoration: none;
-    border: 0;
-    outline: none;
-  }
-
   a img {
-    border: none;
+      border: 0;
+      outline: none;
+      text-decoration: none;
   }
 
   /* General styling */
@@ -43,7 +37,7 @@
   }
 
    table {
-    border-collapse: collapse !important;
+    border-collapse: collapse;
   }
 
 
@@ -65,11 +59,11 @@
   }
 
   .hide {
-    display: none !important;
+    display: none;
   }
 
   .force-full-width {
-    width: 100% !important;
+    width: 100%;
   }
 
 
@@ -80,7 +74,7 @@
       @media screen {
          /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
         td, h1, h2, h3 {
-          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
+          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif';
         }
       }
   </style>
@@ -90,51 +84,51 @@
     @media only screen and (max-width: 480px) {
 
       table[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       table[class="w300"] {
-        width: 300px !important;
+        width: 300px;
       }
 
       table[class="w290"] {
-        width: 290px !important;
+        width: 290px;
       }
 
       td[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       td[class="mobile-center"] {
-        text-align: center !important;
+        text-align: center;
       }
 
       td[class="mobile-padding"] {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-        padding-bottom: 20px !important;
+        padding-left: 20px;
+        padding-right: 20px;
+        padding-bottom: 20px;
       }
 
       td[class="mobile-block"] {
-        display: block !important;
-        width: 100% !important;
-        text-align: left !important;
-        padding-bottom: 20px !important;
+        display: block;
+        width: 100%;
+        text-align: left;
+        padding-bottom: 20px;
       }
 
       td[class="mobile-border"] {
-        border: 0 !important;
+        border: 0;
       }
 
       td[class*="reveal"] {
-        display: block !important;
+        display: block;
 
       }
 
     }
   </style>
 </head>
-<body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
+<body class="body" style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
 <table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
   <tr>
     <td align="center" valign="top" bgcolor="#ffffff"  width="100%">
@@ -154,7 +148,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG); background-color: #8b8284; background-position: center !important;">
+        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG); background-color: #8b8284; background-position: center;">
 
 
 

--- a/templates/skyline/ping.html
+++ b/templates/skyline/ping.html
@@ -11,26 +11,19 @@
 
   img {
     max-width: 600px;
-    outline: none;
-    text-decoration: none;
     -ms-interpolation-mode: bicubic;
   }
 
-  a {
-    text-decoration: none;
-    border: 0;
-    outline: none;
-    color: #21BEB4;
-  }
-
   a img {
-    border: none;
+      border: 0;
+      outline: none;
+/*       text-decoration: none; */
   }
 
   /* General styling */
 
   td, h1, h2, h3  {
-    font-family: Helvetica, Arial, sans-serif;
+    font-family: 'Lato', Helvetica, Arial, sans-serif;
     font-weight: 400;
   }
 
@@ -44,7 +37,7 @@
   }
 
   table {
-    background:
+    background: #ffffff;
   }
 
   h1, h2, h3 {
@@ -53,7 +46,7 @@
     color: #ffffff;
     font-weight: 400;
   }
-
+ 
   h3 {
     color: #21c5ba;
     font-size: 24px;
@@ -65,7 +58,7 @@
       @media screen {
          /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
         td, h1, h2, h3 {
-          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
+          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif';
         }
       }
   </style>
@@ -75,34 +68,34 @@
     @media only screen and (max-width: 480px) {
 
       table[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       table[class="w300"] {
-        width: 300px !important;
+        width: 300px;
       }
 
       table[class="w290"] {
-        width: 290px !important;
+        width: 290px;
       }
 
       td[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       td[class="mobile-center"] {
-        text-align: center !important;
+        text-align: center;
       }
 
       td[class="mobile-padding"] {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-        padding-bottom: 20px !important;
+        padding-left: 20px;
+        padding-right: 20px;
+        padding-bottom: 20px;
       }
     }
   </style>
 </head>
-<body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
+<body class="body" style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
 <table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
   <tr>
     <td align="center" valign="top" bgcolor="#ffffff"  width="100%">
@@ -122,7 +115,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center !important;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />

--- a/templates/skyline/progress.html
+++ b/templates/skyline/progress.html
@@ -21,23 +21,16 @@
 
   /* Take care of image borders and formatting */
 
-  img {
-    max-width: 600px;
-    outline: none;
-    text-decoration: none;
-    -ms-interpolation-mode: bicubic;
-  }
-
-  a {
-    text-decoration: none;
-    border: 0;
-    outline: none;
-  }
-
-  a img {
-    border: none;
-  }
-
+      img {
+	  max-width: 600px;
+	  -ms-interpolation-mode: bicubic;
+      }
+      
+      a img {
+	  border: 0;
+	  outline: none;
+	  text-decoration: none;
+      }
   /* General styling */
 
   td, h1, h2, h3  {
@@ -55,7 +48,7 @@
   }
 
   table {
-    background:
+    background: #ffffff;
   }
 
   h1, h2, h3 {
@@ -76,7 +69,7 @@
       @media screen {
          /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
         td, h1, h2, h3 {
-          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
+          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif';
         }
       }
   </style>
@@ -86,43 +79,43 @@
     @media only screen and (max-width: 480px) {
 
       table[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       table[class="w300"] {
-        width: 300px !important;
+        width: 300px;
       }
 
       table[class="w290"] {
-        width: 290px !important;
+        width: 290px;
       }
 
       td[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       td[class="mobile-center"] {
-        text-align: center !important;
+        text-align: center;
       }
 
       td[class="mobile-padding"] {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-        padding-bottom: 20px !important;
+        padding-left: 20px;
+        padding-right: 20px;
+        padding-bottom: 20px;
       }
 
       img[class="image-resize"] {
-        width: 73px !important;
-        height: 59px !important;
+        width: 73px;
+        height: 59px;
       }
 
       td[class="font-smaller"] {
-        font-size: 14px !important;
+        font-size: 14px;
       }
     }
   </style>
 </head>
-<body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
+<body class="body" style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
 <table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
   <tr>
     <td align="center" valign="top" bgcolor="#ffffff"  width="100%">
@@ -142,7 +135,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center !important;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />

--- a/templates/skyline/reignite.html
+++ b/templates/skyline/reignite.html
@@ -11,19 +11,13 @@
 
   img {
     max-width: 600px;
-    outline: none;
-    text-decoration: none;
     -ms-interpolation-mode: bicubic;
   }
 
-  a {
-    text-decoration: none;
-    border: 0;
-    outline: none;
-  }
-
   a img {
-    border: none;
+      border: 0;
+      outline: none;
+      text-decoration: none;
   }
 
   /* General styling */
@@ -43,7 +37,7 @@
   }
 
   table {
-    background:
+    background: #ffffff;
   }
 
   h1, h2, h3 {
@@ -64,7 +58,7 @@
       @media screen {
          /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
         td, h1, h2, h3 {
-          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
+          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif';
         }
       }
   </style>
@@ -74,34 +68,34 @@
     @media only screen and (max-width: 480px) {
 
       table[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       table[class="w300"] {
-        width: 300px !important;
+        width: 300px;
       }
 
       table[class="w290"] {
-        width: 290px !important;
+        width: 290px;
       }
 
       td[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       td[class="mobile-center"] {
-        text-align: center !important;
+        text-align: center;
       }
 
       td[class="mobile-padding"] {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-        padding-bottom: 20px !important;
+        padding-left: 20px;
+        padding-right: 20px;
+        padding-bottom: 20px;
       }
     }
   </style>
 </head>
-<body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
+<body class="body" style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
 <table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
   <tr>
     <td align="center" valign="top" bgcolor="#ffffff"  width="100%">
@@ -121,7 +115,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center !important;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />
@@ -168,7 +162,7 @@
                   <table style="margin: 0 auto;" cellspacing="0" cellpadding="8" width="250">
                     <tr>
                       <td style="border: 1px solid #a1a1a1; text-align:center;">
-                        Coupon Code: <span style="font-family: Courier !important;">4562789498</span>
+                        Coupon Code: <span style="font-family: Courier;">4562789498</span>
                       </td>
                     </tr>
                   </table>

--- a/templates/skyline/upsell.html
+++ b/templates/skyline/upsell.html
@@ -11,19 +11,13 @@
 
   img {
     max-width: 600px;
-    outline: none;
-    text-decoration: none;
     -ms-interpolation-mode: bicubic;
   }
 
-  a {
-    text-decoration: none;
-    border: 0;
-    outline: none;
-  }
-
   a img {
-    border: none;
+      border: 0;
+      outline: none;
+      text-decoration: none;
   }
 
   /* General styling */
@@ -43,7 +37,7 @@
   }
 
   table {
-    background:
+    background: #ffffff;
   }
 
   h1, h2, h3 {
@@ -64,7 +58,7 @@
       @media screen {
          /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
         td, h1, h2, h3 {
-          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
+          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif';
         }
       }
   </style>
@@ -74,34 +68,34 @@
     @media only screen and (max-width: 480px) {
 
       table[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       table[class="w300"] {
-        width: 300px !important;
+        width: 300px;
       }
 
       table[class="w290"] {
-        width: 290px !important;
+        width: 290px;
       }
 
       td[class="w320"] {
-        width: 320px !important;
+        width: 320px;
       }
 
       td[class="mobile-center"] {
-        text-align: center !important;
+        text-align: center;
       }
 
       td[class="mobile-padding"] {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-        padding-bottom: 20px !important;
+        padding-left: 20px;
+        padding-right: 20px;
+        padding-bottom: 20px;
       }
     }
   </style>
 </head>
-<body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
+<body class="body" style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
 <table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
   <tr>
     <td align="center" valign="top" bgcolor="#ffffff"  width="100%">
@@ -121,7 +115,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center !important;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />

--- a/templates/skyline/welcome.html
+++ b/templates/skyline/welcome.html
@@ -1,283 +1,277 @@
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.0 Transitional//EN" "http://www.w3.org/TR/xhtml1/DTD/xhtml1-transitional.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
-<head>
-	<meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
-	<meta name="viewport" content="width=device-width, initial-scale=1" />
-	<title>Skyline Welcome Email</title>
-	<style type="text/css">
-  @import url(http://fonts.googleapis.com/css?family=Lato:400);
-
-	/* Take care of image borders and formatting */
-
-	img {
-		max-width: 600px;
-		outline: none;
-		text-decoration: none;
-		-ms-interpolation-mode: bicubic;
-	}
-
-  a {
-    text-decoration: none;
-    border: 0;
-    outline: none;
-  }
-
-	a img {
-		border: none;
-	}
-
-  /* General styling */
-
-  td, h1, h2, h3  {
-    font-family: Helvetica, Arial, sans-serif;
-    font-weight: 400;
-  }
-
-  body {
-    -webkit-font-smoothing:antialiased;
-    -webkit-text-size-adjust:none;
-    width: 100%;
-    height: 100%;
-    color: #37302d;
-    background: #ffffff;
-  }
-
-  table {
-    background:
-  }
-
-  h1, h2, h3 {
-    padding: 0;
-    margin: 0;
-    color: #ffffff;
-    font-weight: 400;
-  }
-
-  h3 {
-    color: #21c5ba;
-    font-size: 24px;
-  }
-
-	</style>
-
-  <style type="text/css" media="screen">
+  <head>
+    <meta http-equiv="Content-Type" content="text/html; charset=utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Skyline Welcome Email</title>
+    <style type="text/css">
+      @import url(http://fonts.googleapis.com/css?family=Lato:400);
+      /* Take care of image borders and formatting */
+      
+      img {
+	  max-width: 600px;
+	  -ms-interpolation-mode: bicubic;
+      }
+      
+      a img {
+	  border: 0;
+	  outline: none;
+	  text-decoration: none;
+      }
+      
+      
+      /* General styling */
+      
+      td, h1, h2, h3  {
+	  font-family: Helvetica, Arial, sans-serif;
+	  font-weight: 400;
+      }
+      
+      body {
+	  -webkit-font-smoothing:antialiased;
+	  -webkit-text-size-adjust:none;
+	  width: 100%;
+	  height: 100%;
+	  color: #37302d;
+	  background: #ffffff;
+      }
+      
+      table {
+	  background: #ffffff;
+      }
+      
+      h1, h2, h3 {
+	  padding: 0;
+	  margin: 0;
+	  color: #ffffff;
+	  font-weight: 400;
+      }
+      
+      h3 {
+	  color: #21c5ba;
+	  font-size: 24px;
+      }
+      
+    </style>
+    
+    <style type="text/css" media="screen">
       @media screen {
-         /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
-        td, h1, h2, h3 {
-          font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
-        }
+	  /*Thanks Outlook 2013! http://goo.gl/XLxpyl*/
+	  td, h1, h2, h3 {
+	      font-family: 'Lato', 'Helvetica Neue', 'Arial', 'sans-serif';
+	  }
       }
-  </style>
-
-  <style type="text/css" media="only screen and (max-width: 480px)">
-    /* Mobile styles */
-    @media only screen and (max-width: 480px) {
-
-      table[class="w320"] {
-        width: 320px !important;
+    </style>
+    
+    <style type="text/css" media="only screen and (max-width: 480px)">
+      /* Mobile styles */
+      @media only screen and (max-width: 480px) {
+	  
+	  table[class="w320"] {
+	      width: 320px;
+	  }
+	  
+	  table[class="w300"] {
+	      width: 300px;
+	  }
+	  
+	  table[class="w290"] {
+	      width: 290px;
+	  }
+	  
+	  td[class="w320"] {
+	      width: 320px;
+	  }
+	  
+	  td[class="mobile-center"] {
+	      text-align: center;
+	  }
+	  
+	  td[class="mobile-padding"] {
+	      padding-left: 20px;
+	      padding-right: 20px;
+	      padding-bottom: 20px;
+	  }
       }
-
-      table[class="w300"] {
-        width: 300px !important;
-      }
-
-      table[class="w290"] {
-        width: 290px !important;
-      }
-
-      td[class="w320"] {
-        width: 320px !important;
-      }
-
-      td[class="mobile-center"] {
-        text-align: center !important;
-      }
-
-      td[class="mobile-padding"] {
-        padding-left: 20px !important;
-        padding-right: 20px !important;
-        padding-bottom: 20px !important;
-      }
-    }
-  </style>
-</head>
-<body class="body" style="padding:0 !important; margin:0 !important; display:block !important; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
-<table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
-  <tr>
-    <td align="center" valign="top" bgcolor="#ffffff"  width="100%">
-
-    <table cellspacing="0" cellpadding="0" width="100%">
+    </style>
+  </head>
+  <body class="body" style="padding:0; margin:0; display:block; background:#ffffff; -webkit-text-size-adjust:none" bgcolor="#ffffff">
+    <table align="center" cellpadding="0" cellspacing="0" width="100%" height="100%" >
       <tr>
-        <td style="border-bottom: 3px solid #3bcdc3;" width="100%">
-          <center>
-            <table cellspacing="0" cellpadding="0" width="500" class="w320">
-              <tr>
-                <td valign="top" style="padding:10px 0; text-align:left;" class="mobile-center">
-                  <img width="250" height="62" src="https://www.filepicker.io/api/file/TtSuN5UdTmO0NXWPfYCJ">
-                </td>
-              </tr>
-            </table>
-          </center>
+	<td align="center" valign="top" bgcolor="#ffffff"  width="100%">
+	  
+	  <table cellspacing="0" cellpadding="0" width="100%">
+	    <tr>
+              <td style="border-bottom: 3px solid #3bcdc3;" width="100%">
+		<center>
+		  <table cellspacing="0" cellpadding="0" width="500" class="w320">
+		    <tr>
+                      <td valign="top" style="padding:10px 0; text-align:left;" class="mobile-center">
+			<img width="250" height="62" src="https://www.filepicker.io/api/file/TtSuN5UdTmO0NXWPfYCJ">
+			</td>
+		      </tr>
+		    </table>
+		  </center>
+		</td>
+	      </tr>
+	    <tr>
+              <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
+		<!--[if gte mso 9]>
+		    <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
+		      <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />
+		      <v:textbox inset="0,0,0,0">
+			<![endif]-->
+		<div>
+		  <center>
+		    <table cellspacing="0" cellpadding="0" width="530" height="303" class="w320">
+                      <tr>
+			<td valign="middle" style="vertical-align:middle; padding-right: 15px; padding-left: 15px; text-align:left;" class="mobile-center" height="303">
+			  
+			  <h1>WELCOME TO AWESOME INC!</h1><br>
+			    <h2>We hope you will have<br> an Awesome time!</h2>
+			      
+			    </td>
+			  </tr>
+			</table>
+		      </center>
+		    </div>
+		    <!--[if gte mso 9]>
+			</v:textbox>
+		    </v:rect>
+		    <![endif]-->
+		  </td>
+		</tr>
+		<tr>
+		  <td valign="top">
+		    
+		    <center>
+		      <table cellspacing="0" cellpadding="30" width="500" class="w290">
+			<tr>
+			  <td valign="top" style="border-bottom:1px solid #a1a1a1;">
+			    
+			    <table cellspacing="0" cellpadding="0" width="100%">
+			      <tr>
+				<td style="text-align: center;">
+				  <h3>Free 20% off coupon code for signing-up!</h3>
+				  <br>
+				  </td>
+				</tr>
+			      </table>
+			      
+			      <center>
+				<table style="margin: 0 auto;" cellspacing="0" cellpadding="8" width="180">
+				  <tr>
+				    <td style="border: 1px solid #a1a1a1; text-align:center;">
+				      Code: <span style="font-family: Courier;">4562789498</span>
+				    </td>
+				  </tr>
+				</table>
+			      </center>
+			    </td>
+			  </tr>
+			</table>
+			<table cellspacing="0" cellpadding="0" width="500" class="w320">
+			  <tr>
+			    <td>
+			      
+			      <table cellspacing="0" cellpadding="0" width="100%">
+				<tr>
+				  <td class="mobile-padding" style="text-align:left;">
+				    <br>
+				      We are really excited for you to join our community. Just one click away from activating your account.
+				      <br>
+					<br>
+					  
+					</td>
+				      </tr>
+				    </table>
+				  </td>
+				</tr>
+				<tr>
+				  <td class="mobile-padding">
+				    <table cellspacing="0" cellpadding="0" width="100%">
+				      <tr>
+					<td style="width:150px; background-color: #3bcdc3;">
+					  <div><!--[if mso]>
+						   <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="#" style="height:33px;v-text-anchor:middle;width:150px;" arcsize="8%" stroke="f" fillcolor="#3bcdc3">
+						     <w:anchorlock/>
+						     <center style="color:#ffffff;font-family:sans-serif;font-size:13px;">Activate!</center>
+						   </v:roundrect>
+						   <![endif]-->
+					    <!--[if !mso]><!-- --><a href="#"><table cellspacing="0" cellpadding="0" width="100%"><tr><td style="background-color:#3bcdc3;border-radius:0px;color:#ffffff;display:inline-block;font-family:'Lato', Helvetica, Arial, sans-serif;font-weight:bold;font-size:13px;line-height:33px;text-align:center;text-decoration:none;width:150px;-webkit-text-size-adjust:none;mso-hide:all;"><span style="color:#ffffff">Activate Now</span></td></tr></table></a>
+						      <!--<![endif]-->
+              </div>
+            </td>
+              <td>
+                &nbsp;
+              </td>
+            </tr>
+          </table>
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center !important;">
-          <!--[if gte mso 9]>
-          <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
-            <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />
-            <v:textbox inset="0,0,0,0">
-          <![endif]-->
-          <div>
+        <td>
+          <table cellspacing="0" cellpadding="25" width="100%">
+            <tr>
+              <td>
+                &nbsp;
+              </td>
+            </tr>
+          </table>
+        </td>
+      </tr>
+    </table>
+  </center>
+</td>
+</tr>
+<tr>
+  <td style="background-color:#c2c2c2;">
+    
+    <center>
+      <table cellspacing="0" cellpadding="0" width="500" class="w320">
+        <tr>
+          <td>
+            <table cellspacing="0" cellpadding="30" width="100%">
+              <tr>
+                <td style="text-align:center;">
+                  <a href="#">
+                    <img width="61" height="51" src="https://www.filepicker.io/api/file/vkoOlof0QX6YCDF9cCFV" alt="twitter" />
+                  </a>
+                  <a href="#">
+                    <img width="61" height="51" src="https://www.filepicker.io/api/file/fZaNDx7cSPaE23OX2LbB" alt="google plus" />
+                  </a>
+                  <a href="#">
+                    <img width="61" height="51" src="https://www.filepicker.io/api/file/b3iHzECrTvCPEAcpRKPp" alt="facebook" />
+                  </a>
+                </td>
+              </tr>
+            </table>
+          </td>
+        </tr>
+        <tr>
+          <td>
             <center>
-              <table cellspacing="0" cellpadding="0" width="530" height="303" class="w320">
+              <table style="margin:0 auto;" cellspacing="0" cellpadding="5" width="100%">
                 <tr>
-                  <td valign="middle" style="vertical-align:middle; padding-right: 15px; padding-left: 15px; text-align:left;" class="mobile-center" height="303">
-
-                    <h1>WELCOME TO AWESOME INC!</h1><br>
-                    <h2>We hope you will have<br> an Awesome time!</h2>
-
+                  <td style="text-align:center; margin:0 auto;" width="100%">
+                    <a href="#" style="text-align:center;">
+                      <img style="margin:0 auto;" width="123" height="24" src="https://www.filepicker.io/api/file/u7CkMXcOSlG8TMbr3LnG" alt="logo link" />
+                    </a>
                   </td>
                 </tr>
               </table>
             </center>
-          </div>
-          <!--[if gte mso 9]>
-            </v:textbox>
-          </v:rect>
-          <![endif]-->
-        </td>
-      </tr>
-      <tr>
-        <td valign="top">
+          </td>
+        </tr>
+      </table>
+    </center>
+    
+  </td>
+</tr>
+</table>
 
-          <center>
-            <table cellspacing="0" cellpadding="30" width="500" class="w290">
-              <tr>
-                <td valign="top" style="border-bottom:1px solid #a1a1a1;">
-
-                  <table cellspacing="0" cellpadding="0" width="100%">
-                    <tr>
-                      <td style="text-align: center;">
-                        <h3>Free 20% off coupon code for signing-up!</h3>
-                        <br>
-                      </td>
-                    </tr>
-                  </table>
-
-                  <center>
-                  <table style="margin: 0 auto;" cellspacing="0" cellpadding="8" width="180">
-                    <tr>
-                      <td style="border: 1px solid #a1a1a1; text-align:center;">
-                        Code: <span style="font-family: Courier !important;">4562789498</span>
-                      </td>
-                    </tr>
-                  </table>
-                  </center>
-                </td>
-              </tr>
-            </table>
-            <table cellspacing="0" cellpadding="0" width="500" class="w320">
-              <tr>
-                <td>
-
-                  <table cellspacing="0" cellpadding="0" width="100%">
-                    <tr>
-                      <td class="mobile-padding" style="text-align:left;">
-                      <br>
-                        We are really excited for you to join our community. Just one click away from activating your account.
-                      <br>
-                      <br>
-
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              <tr>
-                <td class="mobile-padding">
-                  <table cellspacing="0" cellpadding="0" width="100%">
-                    <tr>
-                      <td style="width:150px; background-color: #3bcdc3;">
-                        <div><!--[if mso]>
-                            <v:roundrect xmlns:v="urn:schemas-microsoft-com:vml" xmlns:w="urn:schemas-microsoft-com:office:word" href="#" style="height:33px;v-text-anchor:middle;width:150px;" arcsize="8%" stroke="f" fillcolor="#3bcdc3">
-                              <w:anchorlock/>
-                              <center style="color:#ffffff;font-family:sans-serif;font-size:13px;">Activate!</center>
-                            </v:roundrect>
-                          <![endif]-->
-                          <!--[if !mso]><!-- --><a href="#"><table cellspacing="0" cellpadding="0" width="100%"><tr><td style="background-color:#3bcdc3;border-radius:0px;color:#ffffff;display:inline-block;font-family:'Lato', Helvetica, Arial, sans-serif;font-weight:bold;font-size:13px;line-height:33px;text-align:center;text-decoration:none;width:150px;-webkit-text-size-adjust:none;mso-hide:all;"><span style="color:#ffffff">Activate Now</span></td></tr></table></a>
-                          <!--<![endif]-->
-                        </div>
-                      </td>
-                      <td>
-                        &nbsp;
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <table cellspacing="0" cellpadding="25" width="100%">
-                    <tr>
-                      <td>
-                        &nbsp;
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-            </table>
-          </center>
-        </td>
-      </tr>
-      <tr>
-        <td style="background-color:#c2c2c2;">
-
-          <center>
-            <table cellspacing="0" cellpadding="0" width="500" class="w320">
-              <tr>
-                <td>
-                  <table cellspacing="0" cellpadding="30" width="100%">
-                    <tr>
-                      <td style="text-align:center;">
-                        <a href="#">
-                          <img width="61" height="51" src="https://www.filepicker.io/api/file/vkoOlof0QX6YCDF9cCFV" alt="twitter" />
-                        </a>
-                        <a href="#">
-                          <img width="61" height="51" src="https://www.filepicker.io/api/file/fZaNDx7cSPaE23OX2LbB" alt="google plus" />
-                        </a>
-                        <a href="#">
-                          <img width="61" height="51" src="https://www.filepicker.io/api/file/b3iHzECrTvCPEAcpRKPp" alt="facebook" />
-                        </a>
-                      </td>
-                    </tr>
-                  </table>
-                </td>
-              </tr>
-              <tr>
-                <td>
-                  <center>
-                    <table style="margin:0 auto;" cellspacing="0" cellpadding="5" width="100%">
-                      <tr>
-                        <td style="text-align:center; margin:0 auto;" width="100%">
-                           <a href="#" style="text-align:center;">
-                             <img style="margin:0 auto;" width="123" height="24" src="https://www.filepicker.io/api/file/u7CkMXcOSlG8TMbr3LnG" alt="logo link" />
-                           </a>
-                        </td>
-                      </tr>
-                    </table>
-                  </center>
-                </td>
-              </tr>
-            </table>
-          </center>
-
-        </td>
-      </tr>
-    </table>
-
-    </td>
-  </tr>
+</td>
+</tr>
 </table>
 </body>
 </html>


### PR DESCRIPTION
`!important` and some CSS were causing premailer to barf. 
Simplified this:

```
 /* Take care of image borders and formatting */
img {
    max-width: 600px;
    outline: none;
    text-decoration: none;
    -ms-interpolation-mode: bicubic;
}

a {
    text-decoration: none;
    border: 0;
    outline: none;
}

a img {
    border: none;
}
```

To this:

```
  img {
    max-width: 600px;
    -ms-interpolation-mode: bicubic;
  }

  a img {
      border: 0;
      outline: none;
      text-decoration: none;
  }
```
