### PR TITLE
Fixed broken image in Outlook clients

### DIFF
--- a/templates/skyline/invite.html
+++ b/templates/skyline/invite.html
@@ -143,7 +143,7 @@
         <td background="https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" bgcolor="#0d0102" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU); background-color: #0d0102; background-position: center !important;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
-            <v:fill type="tile" src="hhttps://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" color="#0d0102" />
+            <v:fill type="tile" src="https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" color="#0d0102" />
             <v:textbox inset="0,0,0,0">
           <![endif]-->
           <div>


### PR DESCRIPTION
Corrected typo that was breaking the hero image in Outlook versions 2007, 2010 and 2013
