### PR TITLE
Fix skyline background position bug in gmail

### DIFF
--- a/gallery.json
+++ b/gallery.json
@@ -58,7 +58,7 @@
         {
           "title": "confirm",
           "image_url": "https://www.filepicker.io/api/file/YGncYIkFRxOtYKYXMavZ",
-          "litmus_url": "https://litmus.com/pub/6c8a090/screenshots"
+          "litmus_url": "https://litmus.com/pub/146794c/screenshots"
         },
         {
           "title": "invite",

--- a/templates/skyline/confirm.html
+++ b/templates/skyline/confirm.html
@@ -148,7 +148,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG); background-color: #8b8284; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG) no-repeat center; background-color: #8b8284; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" color="#8b8284" />

--- a/templates/skyline/invite.html
+++ b/templates/skyline/invite.html
@@ -138,7 +138,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" bgcolor="#0d0102" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU); background-color: #0d0102; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" bgcolor="#0d0102" valign="top" style="background: url(https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU) no-repeat center; background-color: #0d0102; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/mEwMJfoIQlKlv1u3CSfU" color="#0d0102" />

--- a/templates/skyline/invoice.html
+++ b/templates/skyline/invoice.html
@@ -148,7 +148,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG); background-color: #8b8284; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG) no-repeat center; background-color: #8b8284; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" color="#8b8284" />

--- a/templates/skyline/ping.html
+++ b/templates/skyline/ping.html
@@ -120,7 +120,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz) no-repeat center; background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />

--- a/templates/skyline/progress.html
+++ b/templates/skyline/progress.html
@@ -138,7 +138,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz) no-repeat center; background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />

--- a/templates/skyline/reignite.html
+++ b/templates/skyline/reignite.html
@@ -120,7 +120,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz) no-repeat center; background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />

--- a/templates/skyline/survey.html
+++ b/templates/skyline/survey.html
@@ -176,7 +176,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG); background-color: #8b8284; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" bgcolor="#8b8284" valign="top" style="background: url(https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG) no-repeat center; background-color: #8b8284; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/kmlo6MonRpWsVuuM47EG" color="#8b8284" />

--- a/templates/skyline/upsell.html
+++ b/templates/skyline/upsell.html
@@ -120,7 +120,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz) no-repeat center; background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />

--- a/templates/skyline/welcome.html
+++ b/templates/skyline/welcome.html
@@ -120,7 +120,7 @@
         </td>
       </tr>
       <tr>
-        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: no-repeat url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz); background-color: #64594b; background-position: center;">
+        <td background="https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz" bgcolor="#64594b" valign="top" style="background: url(https://www.filepicker.io/api/file/zLBr1W6UT6qZP4jI2yRz) no-repeat center; background-color: #64594b; background-position: center;">
           <!--[if gte mso 9]>
           <v:rect xmlns:v="urn:schemas-microsoft-com:vml" fill="true" stroke="false" style="mso-width-percent:1000;height:303px;">
             <v:fill type="tile" src="https://www.filepicker.io/api/file/ewEXNrLlTneFGtlB5ryy" color="#64594b" />


### PR DESCRIPTION
Gmail does not support the background-position property and strips it from the
code. The solution is to write the position in the shorthand background
property.

Fixes #13