### PR TITLE
removing short link that offends spam filters

### DIFF
--- a/templates/go/confirm.html
+++ b/templates/go/confirm.html
@@ -92,7 +92,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/go/invite.html
+++ b/templates/go/invite.html
@@ -92,7 +92,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/go/invoice.html
+++ b/templates/go/invoice.html
@@ -102,7 +102,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/go/ping.html
+++ b/templates/go/ping.html
@@ -92,7 +92,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/go/progress.html
+++ b/templates/go/progress.html
@@ -126,7 +126,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/go/reignite.html
+++ b/templates/go/reignite.html
@@ -92,7 +92,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/go/survey.html
+++ b/templates/go/survey.html
@@ -109,7 +109,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/go/upsell.html
+++ b/templates/go/upsell.html
@@ -92,7 +92,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/go/welcome.html
+++ b/templates/go/welcome.html
@@ -92,7 +92,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=PT+Sans:400,700);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'PT Sans', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/narrative/confirm.html
+++ b/templates/narrative/confirm.html
@@ -95,7 +95,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/narrative/invite.html
+++ b/templates/narrative/invite.html
@@ -95,7 +95,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/narrative/invoice.html
+++ b/templates/narrative/invoice.html
@@ -103,7 +103,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/narrative/ping.html
+++ b/templates/narrative/ping.html
@@ -95,7 +95,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/narrative/progress.html
+++ b/templates/narrative/progress.html
@@ -95,7 +95,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/narrative/reignite.html
+++ b/templates/narrative/reignite.html
@@ -95,7 +95,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/narrative/survey.html
+++ b/templates/narrative/survey.html
@@ -114,7 +114,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/narrative/upsell.html
+++ b/templates/narrative/upsell.html
@@ -95,7 +95,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/narrative/welcome.html
+++ b/templates/narrative/welcome.html
@@ -95,7 +95,7 @@
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Open+Sans:400);
 
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         td, h1, h2, h3 {
           font-family: 'Open Sans', 'Helvetica Neue', Arial, sans-serif !important;
         }

--- a/templates/oxygen/confirm.html
+++ b/templates/oxygen/confirm.html
@@ -178,7 +178,7 @@
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/oxygen/invite.html
+++ b/templates/oxygen/invite.html
@@ -191,7 +191,7 @@
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/oxygen/invoice.html
+++ b/templates/oxygen/invoice.html
@@ -177,7 +177,7 @@
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/oxygen/ping.html
+++ b/templates/oxygen/ping.html
@@ -148,7 +148,7 @@
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/oxygen/progress.html
+++ b/templates/oxygen/progress.html
@@ -226,7 +226,7 @@ White Step Three - http://s3.amazonaws.com/swu-filepicker/YSTlgtgaTSa897tPTUhl_v
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/oxygen/reignite.html
+++ b/templates/oxygen/reignite.html
@@ -188,7 +188,7 @@
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/oxygen/survey.html
+++ b/templates/oxygen/survey.html
@@ -190,7 +190,7 @@
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/oxygen/upsell.html
+++ b/templates/oxygen/upsell.html
@@ -139,7 +139,7 @@
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/oxygen/welcome.html
+++ b/templates/oxygen/welcome.html
@@ -138,7 +138,7 @@
 
   <style type="text/css" media="screen">
     @media screen {
-      /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+      /* Thanks Outlook 2013! */
       * {
         font-family: 'Oxygen', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
       }

--- a/templates/sunday/confirm.html
+++ b/templates/sunday/confirm.html
@@ -79,7 +79,7 @@
   <style type="text/css" media="screen">
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         * {
           font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
         }

--- a/templates/sunday/invite.html
+++ b/templates/sunday/invite.html
@@ -68,7 +68,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/sunday/invoice.html
+++ b/templates/sunday/invoice.html
@@ -73,7 +73,7 @@
   <style type="text/css" media="screen">
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         * {
           font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
         }

--- a/templates/sunday/ping.html
+++ b/templates/sunday/ping.html
@@ -68,7 +68,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/sunday/progress.html
+++ b/templates/sunday/progress.html
@@ -77,7 +77,7 @@
     <style type="text/css" media="screen">
         @media screen {
           @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-          /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+          /* Thanks Outlook 2013! */
           * {
             font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
           }

--- a/templates/sunday/reignite.html
+++ b/templates/sunday/reignite.html
@@ -64,7 +64,7 @@
   <style type="text/css" media="screen">
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         * {
           font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
         }

--- a/templates/sunday/survey.html
+++ b/templates/sunday/survey.html
@@ -82,7 +82,7 @@
   <style type="text/css" media="screen">
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         * {
           font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
         }

--- a/templates/sunday/upsell.html
+++ b/templates/sunday/upsell.html
@@ -64,7 +64,7 @@
   <style type="text/css" media="screen">
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         * {
           font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
         }

--- a/templates/sunday/welcome.html
+++ b/templates/sunday/welcome.html
@@ -64,7 +64,7 @@
   <style type="text/css" media="screen">
       @media screen {
         @import url(http://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,900);
-        /* Thanks Outlook 2013! http://goo.gl/XLxpyl */
+        /* Thanks Outlook 2013! */
         * {
           font-family: 'Source Sans Pro', 'Helvetica Neue', 'Arial', 'sans-serif' !important;
         }


### PR DESCRIPTION
Even though the short link is in a comment, certain spam filters (e.g. the one by Barracuda Networks) will still block emails using these templates.